### PR TITLE
To Don't v1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.aar
 *.ap_
 *.aab
+app/release/output-metadata.json
+app/release/output.json
 
 # Files for the ART/Dalvik VM
 *.dex
@@ -38,6 +40,7 @@ captures/
 
 # IntelliJ
 *.iml
+.idea/
 .idea/workspace.xml
 .idea/tasks.xml
 .idea/gradle.xml
@@ -52,15 +55,15 @@ captures/
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.
-#*.jks
-#*.keystore
+*.jks
+*.keystore
 
 # External native build folder generated in Android Studio 2.2 and later
 .externalNativeBuild
 .cxx/
 
 # Google Services (e.g. APIs or Firebase)
-# google-services.json
+google-services.json
 
 # Freeline
 freeline.py

--- a/README.md
+++ b/README.md
@@ -39,11 +39,16 @@ This fast flashlight can be a perfect choice for users with a device that doesnâ
 
 # Contributing
 
-We use [Hosted Weblate](https://hosted.weblate.org/engage/flashy/) for translations.
+The ```development``` or a feature branch is used while developing the code, and pushed into the master branch ```trunk``` afterwards for releases.
+PRs to the ```trunk``` need at least one approving review before getting merged.
+
+Help translate the app at [Hosted Weblate](https://hosted.weblate.org/engage/flashy/).
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 Please make sure to update tests as appropriate.
+
+Check out the [contribution guidelines](https://github.com/Crazy-Marvin/Flashy/blob/trunk/.github/CONTRIBUTING.md) for details please.
 
 # License
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "rocks.poopjournal.flashy"
         minSdkVersion 19
         targetSdkVersion 33
-        versionCode 4
-        versionName "1.3"
+        versionCode 5
+        versionName "1.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/poopjournal/flashy/MainActivity.java
+++ b/app/src/main/java/com/poopjournal/flashy/MainActivity.java
@@ -33,7 +33,8 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
     //Views
     TextView appName;
     CircularSeekBar seekBar;
-    RelativeLayout bg_options, bg_option_circle, rootLayout;
+    RelativeLayout bg_options, bg_option_circle;
+    RelativeLayout rootLayout;
     ImageView iconFlash, iconScreen, powerCenter, powerIconCenter, powerIconCenterStand;
     Dialog FlashDialog = null;
     //Fields

--- a/app/src/main/java/com/poopjournal/flashy/MainActivity.java
+++ b/app/src/main/java/com/poopjournal/flashy/MainActivity.java
@@ -19,17 +19,21 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.material.color.MaterialColors;
+
 import me.tankery.lib.circularseekbar.CircularSeekBar;
 
 public class MainActivity extends AppCompatActivity implements Camera.AutoFocusCallback {
     //Views
+    TextView appName;
     CircularSeekBar seekBar;
-    RelativeLayout bg_options, bg_option_circle;
+    RelativeLayout bg_options, bg_option_circle, rootLayout;
     ImageView iconFlash, iconScreen, powerCenter, powerIconCenter, powerIconCenterStand;
     Dialog FlashDialog = null;
     //Fields
@@ -95,6 +99,9 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
         seekBar.setProgress(0F);
         seekBar.setEnabled(false);
         seekBar.setPointerColor(Color.parseColor("#AAAABB"));
+        rootLayout.setBackgroundColor(Color.parseColor("#00000000")); //transparent
+        if (MaterialColors.getColor(this, android.R.attr.textColor, Color.BLUE) == Color.parseColor("#FFFFFF")) //are we using dark theme?
+            appName.setTextColor(Color.parseColor("#FFFFFF")); //if so, set app name to white
         boolean hasFlash = getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH);
         if (!hasFlash) {
             FlashDialog = DialogsUtil.showNoFlashLightDialog(this);
@@ -150,6 +157,8 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
         seekBar.setEnabled(true);
         powerCenter.setOnClickListener(null);
         if (getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)) turnOff();
+        rootLayout.setBackgroundColor(Color.parseColor("#FFFFFF")); //force set white, because it does not make sense for the app to be dark when using screen light
+        appName.setTextColor(Color.parseColor("#000000")); //black
         seekBar.setOnSeekBarChangeListener(new CircularSeekBar.OnCircularSeekBarChangeListener() {
             @Override
             public void onProgressChanged(CircularSeekBar circularSeekBar, float progress, boolean fromUser) {
@@ -179,6 +188,7 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
     }
 
     void findViews() {
+        appName = findViewById(R.id.app_name);
         seekBar = findViewById(R.id.progress_circular);
         bg_options = findViewById(R.id.bg_options);
         bg_option_circle = findViewById(R.id.bg_option_circle);
@@ -187,6 +197,7 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
         powerCenter = findViewById(R.id.power_center);
         powerIconCenter = findViewById(R.id.power_icon_center);
         powerIconCenterStand = findViewById(R.id.power_icon_center_stand);
+        rootLayout = findViewById(R.id.root_layout);
     }
 
     public void turnOn() {

--- a/app/src/main/res/layout-land/main_activity.xml
+++ b/app/src/main/res/layout-land/main_activity.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root_layout"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <TextView
+        android:id="@+id/app_name"
         android:layout_width="wrap_content"
         android:layout_marginTop="16dp"
         android:layout_centerHorizontal="true"

--- a/app/src/main/res/layout-land/main_activity.xml
+++ b/app/src/main/res/layout-land/main_activity.xml
@@ -2,15 +2,17 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
-    android:background="#FFFFFF"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ImageView
-        android:src="@drawable/ic_flashy_title"
-        android:layout_width="match_parent"
-        android:layout_marginTop="24dp"
-        android:layout_height="wrap_content"/>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_centerHorizontal="true"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"/>
     <me.tankery.lib.circularseekbar.CircularSeekBar
         android:id="@+id/progress_circular"
         android:layout_centerInParent="true"

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root_layout"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <TextView
+        android:id="@+id/app_name"
         android:layout_width="wrap_content"
         android:layout_marginTop="16dp"
         android:layout_centerHorizontal="true"

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -2,15 +2,17 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
-    android:background="#FFFFFF"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ImageView
-        android:src="@drawable/ic_flashy_title"
-        android:layout_width="match_parent"
-        android:layout_marginTop="24dp"
-        android:layout_height="wrap_content"/>
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_centerHorizontal="true"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_height="wrap_content"
+        android:text="@string/app_name"/>
     <me.tankery.lib.circularseekbar.CircularSeekBar
         android:id="@+id/progress_circular"
         android:layout_centerInParent="true"

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Flashy</string>
+    <string name="flashlight">Svjetiljka</string>
+    <string name="no_camera">Nema kamere</string>
+    <string name="cannot_access_camera">Nije moguće pristupiti kameri. Koristi li ju jedna druga aplikacija\?</string>
 </resources>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -6,7 +6,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textColor">@android:color/white</item>
     </style>
 
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources></resources>

--- a/fastlane/metadata/android/en-US/changelogs/5.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5.txt
@@ -1,0 +1,3 @@
+- Add Dark Theme 🧛 (#60)
+Note: The app forcibly switches to light theme when using screen light. This is by design, since it does not make sense to use a dark background to light up the screen.
+Huge thanks goes to @unbiaseduser for this feature.

--- a/fastlane/metadata/android/es-ES/changelogs/4.txt
+++ b/fastlane/metadata/android/es-ES/changelogs/4.txt
@@ -1,0 +1,7 @@
+- 📷 Evitar el permiso de la cámara (#41)
+- 🎨 Añadir baldosa de ajustes rápidos (#10)
+- 🎨 Apoyar el icono temático en Android 13+ (#53)
+- 💁🏽 Añadir widget básico (#27)
+- 👍 Actualizar dependencias y traducciones
+
+¡Muchas gracias a @unbiaseduser, @FahadSaleem y a todos los traductores! 😘

--- a/fastlane/metadata/android/hr/changelogs/4.txt
+++ b/fastlane/metadata/android/hr/changelogs/4.txt
@@ -1,0 +1,7 @@
+- 📷 Izbjegni dozvolu kamere (#41)
+- 🎨 Dodaj ploču brzih postavki (#10)
+- 🎨 Podrška tematske ikone na Androidu 13+ (#53)
+- 💁🏽 Dodaj osnovni widget (#27)
+- 👍 Aktualiziraj ovisnosti i prijevode
+
+Puno hvala @unbiaseduser, @FahadSaleem i svim prevoditeljima! 😘


### PR DESCRIPTION
- Add Dark Theme 🧛 (#60)

**Note: The app forcibly switches to light theme when using screen light. This is by design, since it does not make sense to use a dark background to light up the screen.**

Huge thanks goes to @unbiaseduser for this feature.