### PR TITLE
Use view binding instead of findViewById

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    buildFeatures {
+        viewBinding true
+    }
     namespace 'rocks.poopjournal.flashy'
 }
 

--- a/app/src/main/java/rocks/poopjournal/flashy/AboutActivity.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/AboutActivity.java
@@ -5,37 +5,30 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
+
+import rocks.poopjournal.flashy.databinding.ActivityAboutBinding;
 
 public class AboutActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_about);
-        Toolbar toolbar = findViewById(R.id.toolbar_about);
-        setSupportActionBar(toolbar);
+        ActivityAboutBinding binding = ActivityAboutBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+        setSupportActionBar(binding.toolbarAbout);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null)
             actionBar.setDisplayHomeAsUpEnabled(true);
-        TextView appVersion = findViewById(R.id.app_version);
-        appVersion.setText(getString(R.string.version_license, BuildConfig.VERSION_NAME));
-        setupClickToGoToWebsite(appVersion, "https://github.com/Crazy-Marvin/Flashy/blob/development/LICENSE");
-        ImageView appIcon = findViewById(R.id.app_icon);
-        setupClickToGoToWebsite(appIcon, "https://crazymarvin.com/flashy/");
-        ImageView fahadSaleemGithub = findViewById(R.id.fahadsaleem_github);
-        setupClickToGoToWebsite(fahadSaleemGithub, "https://github.com/FahadSaleem/");
-        ImageView crazyMarvinGithub = findViewById(R.id.crazymarvin_github);
-        setupClickToGoToWebsite(crazyMarvinGithub, "https://github.com/CrazyMarvin/");
-        ImageView crazyMarvinEmail = findViewById(R.id.crazymarvin_email);
-        crazyMarvinEmail.setOnClickListener(v -> {
+        binding.appVersion.setText(getString(R.string.version_license, BuildConfig.VERSION_NAME));
+        setupClickToGoToWebsite(binding.appVersion, "https://github.com/Crazy-Marvin/Flashy/blob/development/LICENSE");
+        setupClickToGoToWebsite(binding.appIcon, "https://crazymarvin.com/flashy/");
+        setupClickToGoToWebsite(binding.fahadsaleemGithub, "https://github.com/FahadSaleem/");
+        setupClickToGoToWebsite(binding.crazymarvinGithub, "https://github.com/CrazyMarvin/");
+        binding.crazymarvinEmail.setOnClickListener(v -> {
             try {
                 Intent intent = new Intent(Intent.ACTION_SENDTO)
                         .setData(Uri.parse("mailto:"))
@@ -47,26 +40,16 @@ public class AboutActivity extends AppCompatActivity {
                 Toast.makeText(this, R.string.no_app_can_handle, Toast.LENGTH_SHORT).show();
             }
         });
-        ImageView crazyMarvinTwitter = findViewById(R.id.crazymarvin_twitter);
-        setupClickToGoToWebsite(crazyMarvinTwitter, "https://twitter.com/CrazyMarvinApps");
-        TextView sourceCode = findViewById(R.id.source_code);
-        setupClickToGoToWebsite(sourceCode, "https://github.com/Crazy-Marvin/Flashy");
-        TextView reportProblem = findViewById(R.id.report_problem);
-        setupClickToGoToWebsite(reportProblem, "https://github.com/Crazy-Marvin/Flashy/issues");
-        TextView translate = findViewById(R.id.translate);
-        setupClickToGoToWebsite(translate, "https://hosted.weblate.org/engage/flashy/");
-        LinearLayout featherIcons = findViewById(R.id.feather_icons);
-        setupClickToGoToWebsite(featherIcons, "https://feathericons.com/");
-        LinearLayout mdIcons = findViewById(R.id.md_icons);
-        setupClickToGoToWebsite(mdIcons, "https://fonts.google.com/icons");
-        LinearLayout jetpack = findViewById(R.id.jetpack);
-        setupClickToGoToWebsite(jetpack, "https://developer.android.com/jetpack");
-        LinearLayout circularSeekBar = findViewById(R.id.circular_seekbar);
-        setupClickToGoToWebsite(circularSeekBar, "https://github.com/tankery/CircularSeekBar");
-        LinearLayout kotlin = findViewById(R.id.kotlin);
-        setupClickToGoToWebsite(kotlin, "https://github.com/JetBrains/kotlin/blob/master/license/LICENSE.txt");
-        LinearLayout java = findViewById(R.id.java);
-        setupClickToGoToWebsite(java, "http://openjdk.java.net/legal/gplv2+ce.html");
+        setupClickToGoToWebsite(binding.crazymarvinTwitter, "https://twitter.com/CrazyMarvinApps");
+        setupClickToGoToWebsite(binding.sourceCode, "https://github.com/Crazy-Marvin/Flashy");
+        setupClickToGoToWebsite(binding.reportProblem, "https://github.com/Crazy-Marvin/Flashy/issues");
+        setupClickToGoToWebsite(binding.translate, "https://hosted.weblate.org/engage/flashy/");
+        setupClickToGoToWebsite(binding.featherIcons, "https://feathericons.com/");
+        setupClickToGoToWebsite(binding.mdIcons, "https://fonts.google.com/icons");
+        setupClickToGoToWebsite(binding.jetpack, "https://developer.android.com/jetpack");
+        setupClickToGoToWebsite(binding.circularSeekbar, "https://github.com/tankery/CircularSeekBar");
+        setupClickToGoToWebsite(binding.kotlin, "https://github.com/JetBrains/kotlin/blob/master/license/LICENSE.txt");
+        setupClickToGoToWebsite(binding.java, "http://openjdk.java.net/legal/gplv2+ce.html");
     }
 
     private void setupClickToGoToWebsite(View view, String url) {

--- a/app/src/main/java/rocks/poopjournal/flashy/GrantSystemWritePermissionActivity.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/GrantSystemWritePermissionActivity.java
@@ -6,21 +6,19 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
-import android.widget.Button;
-import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import rocks.poopjournal.flashy.databinding.ActivityGrantSystemWritePermissionBinding;
+
 public class GrantSystemWritePermissionActivity extends AppCompatActivity {
-    TextView noticeGrantPermission;
-    Button buttonGrantPermission;
+    private ActivityGrantSystemWritePermissionBinding binding;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_grant_system_write_permission);
-        noticeGrantPermission = findViewById(R.id.notice_grant_permission);
-        buttonGrantPermission = findViewById(R.id.button_grant_permission);
+        binding = ActivityGrantSystemWritePermissionBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1) completeWidgetSetup();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Settings.System.canWrite(this)) completeWidgetSetup();
     }
@@ -29,15 +27,15 @@ public class GrantSystemWritePermissionActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.System.canWrite(this)) {
-            noticeGrantPermission.setText(R.string.system_settings_permission_notice);
-            buttonGrantPermission.setOnClickListener(v -> {
+            binding.noticeGrantPermission.setText(R.string.system_settings_permission_notice);
+            binding.buttonGrantPermission.setOnClickListener(v -> {
                 Intent intent = new Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS)
                         .setData(Uri.parse("package:" + getPackageName()));
                 startActivity(intent);
             });
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            noticeGrantPermission.setText(R.string.system_settings_permission_granted);
-            buttonGrantPermission.setEnabled(false);
+            binding.noticeGrantPermission.setText(R.string.system_settings_permission_granted);
+            binding.buttonGrantPermission.setEnabled(false);
         }
     }
 

--- a/app/src/main/java/rocks/poopjournal/flashy/MainActivity.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/MainActivity.java
@@ -14,28 +14,23 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.Window;
 import android.view.WindowManager;
-import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import androidx.preference.PreferenceManager;
 
 import me.tankery.lib.circularseekbar.CircularSeekBar;
+import rocks.poopjournal.flashy.databinding.MainActivityBinding;
 
 public class MainActivity extends AppCompatActivity implements Camera.AutoFocusCallback {
-    //Views
-    CircularSeekBar seekBar;
-    RelativeLayout bg_options, bg_option_circle;
-    RelativeLayout rootLayout;
-    ImageView iconFlash, iconScreen, powerCenter, powerIconCenter, powerIconCenterStand;
     //Fields
     private int brightness = -999;
     private Window window;
     private SharedPreferences preferences;
     private CameraHelper helper;
+    private MainActivityBinding binding;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -45,13 +40,12 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
             defaultPref.edit().putString("theme", "light").apply();
         Utils.applyThemeFromSettings(this);
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.main_activity);
+        binding = MainActivityBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
         helper = CameraHelper.getInstance(this);
-        Toolbar toolbar = findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
+        setSupportActionBar(binding.toolbar);
         window = getWindow();
         preferences = getSharedPreferences("my_prefs", MODE_PRIVATE);
-        findViews();
         applyListeners();
         CameraHelper.isFlashOn.observe(this, (isOn -> {
             changePowerButtonColors(isOn);
@@ -66,7 +60,8 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
             window.setAttributes(layoutpars);
         }
 
-        getSupportFragmentManager().setFragmentResultListener(NoFlashlightDialog.NO_FLASH_DIALOG_DISMISSED, this, ((requestKey, result) -> bg_options.callOnClick()));
+        if (!getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH))
+            getSupportFragmentManager().setFragmentResultListener(NoFlashlightDialog.NO_FLASH_DIALOG_DISMISSED, this, ((requestKey, result) -> binding.bgOptions.callOnClick()));
     }
 
     @Override
@@ -89,7 +84,7 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
     }
 
     void applyListeners() {
-        bg_options.setOnClickListener(view -> {
+        binding.bgOptions.setOnClickListener(view -> {
             SharedPreferences.Editor editor = preferences.edit();
             editor.putInt("default_option", preferences.getInt("default_option", 1) == 1 ? 2 : 1);
             editor.apply();
@@ -109,61 +104,61 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
 
     void refreshActivityForFlashLight() {
         //Refresh Seekbar
-        seekBar.setOnSeekBarChangeListener(null);
-        seekBar.setProgress(0F);
-        seekBar.setEnabled(false);
-        seekBar.setPointerColor(Color.parseColor("#AAAABB"));
-        rootLayout.setBackgroundColor(Color.parseColor("#00000000")); //transparent
+        binding.progressCircular.setOnSeekBarChangeListener(null);
+        binding.progressCircular.setProgress(0F);
+        binding.progressCircular.setEnabled(false);
+        binding.progressCircular.setPointerColor(Color.parseColor("#AAAABB"));
+        binding.rootLayout.setBackgroundColor(Color.parseColor("#00000000")); //transparent
         boolean hasFlash = getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH);
         if (!hasFlash) {
-            powerCenter.setOnClickListener(null);
+            binding.powerCenter.setOnClickListener(null);
             new NoFlashlightDialog().show(getSupportFragmentManager(), null);
         } else {
-            powerCenter.setOnClickListener(view -> toggle());
+            binding.powerCenter.setOnClickListener(view -> toggle());
         }
     }
 
     void changePowerButtonColors(boolean isTurnedOn) {
         if (isTurnedOn) {
-            powerCenter.setColorFilter(Color.parseColor("#28FFB137"));
-            powerIconCenter.setColorFilter(Color.parseColor("#FFB137"));
-            powerIconCenterStand.setColorFilter(Color.parseColor("#FFB137"));
+            binding.powerCenter.setColorFilter(Color.parseColor("#28FFB137"));
+            binding.powerIconCenter.setColorFilter(Color.parseColor("#FFB137"));
+            binding.powerIconCenterStand.setColorFilter(Color.parseColor("#FFB137"));
         } else {
             //Refresh Power Button
-            powerCenter.setColorFilter(Color.parseColor("#F3F3F7"));
-            powerIconCenter.setColorFilter(Color.parseColor("#AAAABB"));
-            powerIconCenterStand.setColorFilter(Color.parseColor("#AAAABB"));
+            binding.powerCenter.setColorFilter(Color.parseColor("#F3F3F7"));
+            binding.powerIconCenter.setColorFilter(Color.parseColor("#AAAABB"));
+            binding.powerIconCenterStand.setColorFilter(Color.parseColor("#AAAABB"));
         }
     }
 
     void updateOptionsUI(boolean isFlash) {
         if (isFlash) {
             //Change UI for options
-            RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) bg_option_circle.getLayoutParams();
+            RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) binding.bgOptionCircle.getLayoutParams();
             params.removeRule(RelativeLayout.ALIGN_PARENT_END);
-            bg_option_circle.setLayoutParams(params);
-            iconFlash.setColorFilter(Color.parseColor("#FFB137"));
-            iconScreen.setColorFilter(Color.parseColor("#AAAABB"));
-            seekBar.setProgress(0f);
+            binding.bgOptionCircle.setLayoutParams(params);
+            binding.flashIcon.setColorFilter(Color.parseColor("#FFB137"));
+            binding.screenIcon.setColorFilter(Color.parseColor("#AAAABB"));
+            binding.progressCircular.setProgress(0f);
         } else {
-            bg_option_circle.getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
-            RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) bg_option_circle.getLayoutParams();
+            binding.bgOptionCircle.getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
+            RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) binding.bgOptionCircle.getLayoutParams();
             params.addRule(RelativeLayout.ALIGN_PARENT_END);
-            bg_option_circle.setLayoutParams(params);
-            iconFlash.setColorFilter(Color.parseColor("#AAAABB"));
-            iconScreen.setColorFilter(Color.parseColor("#FFB137"));
+            binding.bgOptionCircle.setLayoutParams(params);
+            binding.flashIcon.setColorFilter(Color.parseColor("#AAAABB"));
+            binding.screenIcon.setColorFilter(Color.parseColor("#FFB137"));
         }
     }
 
     void refreshActivityForScreenLight() {
-        seekBar.setPointerColor(Color.parseColor("#FFB137"));
-        seekBar.setEnabled(true);
-        powerCenter.setOnClickListener(null);
+        binding.progressCircular.setPointerColor(Color.parseColor("#FFB137"));
+        binding.progressCircular.setEnabled(true);
+        binding.powerCenter.setOnClickListener(null);
         SharedPreferences defaultPref = PreferenceManager.getDefaultSharedPreferences(this);
         if (defaultPref.getBoolean("no_flash_when_screen", true) && getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH))
             turnOff();
-        rootLayout.setBackgroundColor(Color.parseColor("#FFFFFF")); //force set white, because it does not make sense for the app to be dark when using screen light
-        seekBar.setOnSeekBarChangeListener(new CircularSeekBar.OnCircularSeekBarChangeListener() {
+        binding.rootLayout.setBackgroundColor(Color.parseColor("#FFFFFF")); //force set white, because it does not make sense for the app to be dark when using screen light
+        binding.progressCircular.setOnSeekBarChangeListener(new CircularSeekBar.OnCircularSeekBarChangeListener() {
             @Override
             public void onProgressChanged(CircularSeekBar circularSeekBar, float progress, boolean fromUser) {
                 brightness = (int) progress;
@@ -182,25 +177,7 @@ public class MainActivity extends AppCompatActivity implements Camera.AutoFocusC
 
             }
         });
-        powerCenter.setOnClickListener(view -> {
-            if (brightness != 100) {
-                seekBar.setProgress(100);
-            } else {
-                seekBar.setProgress(0);
-            }
-        });
-    }
-
-    void findViews() {
-        seekBar = findViewById(R.id.progress_circular);
-        bg_options = findViewById(R.id.bg_options);
-        bg_option_circle = findViewById(R.id.bg_option_circle);
-        iconFlash = findViewById(R.id.flash_icon);
-        iconScreen = findViewById(R.id.screen_icon);
-        powerCenter = findViewById(R.id.power_center);
-        powerIconCenter = findViewById(R.id.power_icon_center);
-        powerIconCenterStand = findViewById(R.id.power_icon_center_stand);
-        rootLayout = findViewById(R.id.root_layout);
+        binding.powerCenter.setOnClickListener(view -> binding.progressCircular.setProgress(brightness != 100 ? 100 : 0));
     }
 
     public void toggle() {

--- a/app/src/main/java/rocks/poopjournal/flashy/NoFlashlightDialog.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/NoFlashlightDialog.java
@@ -11,17 +11,19 @@ import androidx.annotation.Nullable;
 import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 
+import rocks.poopjournal.flashy.databinding.DialogNoFlashlightBinding;
+
 public class NoFlashlightDialog extends BottomSheetDialogFragment {
     public static final String NO_FLASH_DIALOG_DISMISSED = "no_flash_dialog_dismissed";
+    private DialogNoFlashlightBinding binding;
 
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        binding = DialogNoFlashlightBinding.inflate(requireActivity().getLayoutInflater());
         BottomSheetDialog dialog = new BottomSheetDialog(requireContext());
-        dialog.setContentView(R.layout.dialog_no_flashlight);
-        RelativeLayout useScreenButton = dialog.findViewById(R.id.container_use_screen);
-        assert useScreenButton != null;
-        useScreenButton.setOnClickListener(v -> dismiss());
+        dialog.setContentView(binding.getRoot());
+        binding.containerUseScreen.setOnClickListener(v -> dismiss());
         return dialog;
     }
 
@@ -29,5 +31,6 @@ public class NoFlashlightDialog extends BottomSheetDialogFragment {
     public void onDismiss(@NonNull DialogInterface dialog) {
         super.onDismiss(dialog);
         getParentFragmentManager().setFragmentResult(NO_FLASH_DIALOG_DISMISSED, new Bundle());
+        binding = null;
     }
 }

--- a/app/src/main/java/rocks/poopjournal/flashy/SettingsActivity.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/SettingsActivity.java
@@ -4,9 +4,10 @@ import android.os.Build;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import androidx.preference.ListPreference;
 import androidx.preference.PreferenceFragmentCompat;
+
+import rocks.poopjournal.flashy.databinding.SettingsActivityBinding;
 
 public class SettingsActivity extends AppCompatActivity {
 
@@ -14,15 +15,15 @@ public class SettingsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         Utils.applyThemeFromSettings(this);
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.settings_activity);
+        SettingsActivityBinding binding = SettingsActivityBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
         if (savedInstanceState == null) {
             getSupportFragmentManager()
                     .beginTransaction()
                     .replace(R.id.settings, new SettingsFragment())
                     .commit();
         }
-        Toolbar toolbar = findViewById(R.id.toolbar_settings);
-        setSupportActionBar(toolbar);
+        setSupportActionBar(binding.toolbarSettings);
         if (getSupportActionBar() != null)
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }

--- a/app/src/main/res/layout/activity_grant_system_write_permission.xml
+++ b/app/src/main/res/layout/activity_grant_system_write_permission.xml
@@ -10,7 +10,7 @@
         android:id="@+id/notice_grant_permission"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="10dp"
+        android:paddingHorizontal="10dp"
         app:layout_constraintBottom_toTopOf="@id/button_grant_permission"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
I converted the code to use [View Binding](https://developer.android.com/topic/libraries/view-binding?hl=en) instead of `findViewById`. It results in much cleaner code and easier maintenance. I'll just quote Google here:
> _View binding_ is a feature that allows you to more easily write code that interacts with views. Once view binding is enabled in a module, it generates a _binding class_ for each XML layout file present in that module. An instance of a binding class contains direct references to all views that have an ID in the corresponding layout.
In most cases, view binding replaces `findViewById`.