### PR TITLE
Fix widgets display names

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,8 @@
 
         <receiver
             android:name=".FlashlightWidgetProvider"
-            android:exported="false">
+            android:exported="false"
+            android:label="@string/flashlight">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -54,7 +55,8 @@
         </receiver>
         <receiver
             android:name=".ScreenBrightnessWidgetProvider"
-            android:exported="false">
+            android:exported="false"
+            android:label="@string/maximize_screen_brightness">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -65,7 +67,8 @@
         </receiver>
         <receiver
             android:name=".SOSWidgetProvider"
-            android:exported="false">
+            android:exported="false"
+            android:label="@string/sos">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>
@@ -90,7 +93,8 @@
         <activity
             android:name=".AboutActivity"
             android:exported="false"
-            android:parentActivityName=".MainActivity">
+            android:parentActivityName=".MainActivity"
+            android:label="@string/about">
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />


### PR DESCRIPTION
I just realized I forgot to include this fix in the last PR.
Anyway, if you want to know what this does, it basically makes the widgets display correct names in the Launcher's widget selection screen instead of the app's name.
Here:
![Screenshot_20221008-174048239 (1)](https://user-images.githubusercontent.com/95969852/194703759-0a9a45c5-f7f7-4f63-b5d0-53ec1e40f55c.jpg)
