### PR TITLE
Fix theme settings strings not being translatable

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,8 +1,8 @@
 <resources>
-    <string-array name="theme_entries">
-        <item>Light</item>
-        <item>Dark</item>
-        <item>Follow system</item>
+    <string-array name="theme_entries" translatable="false">
+        <item>@string/light</item>
+        <item>@string/dark</item>
+        <item>@string/follow_system</item>
     </string-array>
 
     <string-array name="theme_values" translatable="false">
@@ -11,9 +11,9 @@
         <item>system</item>
     </string-array>
 
-    <string-array name="theme_entries_p">
-        <item>Light</item>
-        <item>Dark</item>
+    <string-array name="theme_entries_p" translatable="false">
+        <item>@string/light</item>
+        <item>@string/dark</item>
     </string-array>
 
     <string-array name="theme_values_p" translatable="false">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,9 @@
     <string name="general">General</string>
     <string name="appearance">Appearance</string>
     <string name="theme">Theme</string>
+    <string name="light">Light</string>
+    <string name="dark">Dark</string>
+    <string name="follow_system">Follow system</string>
     <string name="no_flash_when_screen">Turn off flashlight on screen mode</string>
     <string name="about">About</string>
     <string name="version_license">Version %s · Apache License 2.0</string>


### PR DESCRIPTION
I just realized that [Weblate doesn't support string arrays](https://docs.weblate.org/en/latest/formats.html#aresource) (which is used by the theme setting) so I extracted them to individual strings that Weblate can pick up.