### PR TITLE
Add option to turn off flash on screen off

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/rocks/poopjournal/flashy/QSTileService.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/QSTileService.java
@@ -22,7 +22,7 @@ public class QSTileService extends TileService {
     @Override
     public void onStartListening() {
         super.onStartListening();
-        getQsTile().setState(Boolean.TRUE.equals(CameraHelper.getNormalFlashStatus().getValue()) ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE);
+        getQsTile().setState(Boolean.TRUE.equals(helper.getNormalFlashStatus().getValue()) ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE);
         getQsTile().updateTile();
     }
 
@@ -34,7 +34,7 @@ public class QSTileService extends TileService {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 getQsTile().setSubtitle(getString(R.string.no_camera));
             }
-        } else if (Boolean.TRUE.equals(CameraHelper.getNormalFlashStatus().getValue())) {
+        } else if (Boolean.TRUE.equals(helper.getNormalFlashStatus().getValue())) {
             getQsTile().setState(Tile.STATE_ACTIVE);
         }
         getQsTile().updateTile();
@@ -43,16 +43,14 @@ public class QSTileService extends TileService {
     @Override
     public void onTileRemoved() {
         super.onTileRemoved();
-        if (Boolean.TRUE.equals(CameraHelper.getNormalFlashStatus().getValue())) {
-            helper.toggleNormalFlash(this);
-        }
+        helper.turnOffNormalFlash(this);
     }
 
     @Override
     public void onClick() {
         super.onClick();
         helper.toggleNormalFlash(this);
-        getQsTile().setState(Boolean.TRUE.equals(CameraHelper.getNormalFlashStatus().getValue()) ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE);
+        getQsTile().setState(Boolean.TRUE.equals(helper.getNormalFlashStatus().getValue()) ? Tile.STATE_ACTIVE : Tile.STATE_INACTIVE);
         getQsTile().updateTile();
     }
 }

--- a/app/src/main/java/rocks/poopjournal/flashy/activities/MainActivity.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/activities/MainActivity.java
@@ -1,12 +1,15 @@
 package rocks.poopjournal.flashy.activities;
 
 import android.animation.LayoutTransition;
+import android.content.BroadcastReceiver;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -25,6 +28,7 @@ import me.tankery.lib.circularseekbar.CircularSeekBar;
 import rocks.poopjournal.flashy.NoFlashlightDialog;
 import rocks.poopjournal.flashy.R;
 import rocks.poopjournal.flashy.databinding.MainActivityBinding;
+import rocks.poopjournal.flashy.receivers.ScreenOffBroadcastReceiver;
 import rocks.poopjournal.flashy.utils.CameraHelper;
 import rocks.poopjournal.flashy.utils.Shortcuts;
 import rocks.poopjournal.flashy.utils.Utils;
@@ -37,17 +41,34 @@ public class MainActivity extends AppCompatActivity {
     private SharedPreferences defaultPreferences;
     private CameraHelper helper;
     private MainActivityBinding binding;
+    private final BroadcastReceiver turnOffFlashlightOnScreenOffReceiver = new ScreenOffBroadcastReceiver();
     private enum FlashlightMode {
         NORMAL, SOS, STROBOSCOPE
     }
     private final SharedPreferences.OnSharedPreferenceChangeListener material3Listener = (sharedPreferences, key) -> {
-        if (key.equals("md3")) recreate();
+        switch (key) {
+            case "md3":
+                recreate();
+                break;
+            case "no_flash_on_device_screen_off":
+                if (sharedPreferences.getBoolean("no_flash_on_device_screen_off", false)) {
+                    registerReceiver(turnOffFlashlightOnScreenOffReceiver, new IntentFilter(Intent.ACTION_SCREEN_OFF));
+                } else {
+                    unregisterReceiver(turnOffFlashlightOnScreenOffReceiver);
+                }
+                break;
+            default:
+                Log.v(getClass().getSimpleName(), "Preference key received: " + key);
+        }
     };
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         PreferenceManager.setDefaultValues(this, R.xml.root_preferences, false);
         defaultPreferences = PreferenceManager.getDefaultSharedPreferences(this);
+        if (defaultPreferences.getBoolean("no_flash_on_device_screen_off", false)) {
+            registerReceiver(turnOffFlashlightOnScreenOffReceiver, new IntentFilter(Intent.ACTION_SCREEN_OFF));
+        }
         defaultPreferences.registerOnSharedPreferenceChangeListener(material3Listener);
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P && defaultPreferences.getString("theme", "system").equals("system"))
             defaultPreferences.edit().putString("theme", "light").apply();
@@ -61,11 +82,11 @@ public class MainActivity extends AppCompatActivity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
                 helper.getFlashlightStrengthLevel(this) > 1 &&
                 defaultPreferences.getInt("flashlight_strength", -1) == -1) { //if flash brightness is not saved into preferences
-            CameraHelper.setFlashlightStrength(helper.getFlashlightStrengthLevel(this)); //then set brightness to max
+            helper.setFlashlightStrength(helper.getFlashlightStrengthLevel(this)); //then set brightness to max
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
                 helper.getFlashlightStrengthLevel(this) > 1 &&
                 defaultPreferences.getInt("flashlight_strength", -1) != -1) { //if flash brightness is saved into preferences
-            CameraHelper.setFlashlightStrength(defaultPreferences.getInt("flashlight_strength", -1)); //then set brightness from there
+            helper.setFlashlightStrength(defaultPreferences.getInt("flashlight_strength", -1)); //then set brightness from there
         }
         setSupportActionBar(binding.toolbar);
         window = getWindow();
@@ -88,9 +109,9 @@ public class MainActivity extends AppCompatActivity {
             binding.stroboscopeInterval.setVisibility(View.GONE);
             binding.stroboscopeIntervalSlider.setVisibility(View.GONE);
         } else {
-            CameraHelper.getNormalFlashStatus().observe(this, (isOn -> changeButtonColors(FlashlightMode.NORMAL, isOn)));
-            CameraHelper.getSosStatus().observe(this, (isOn -> changeButtonColors(FlashlightMode.SOS, isOn)));
-            CameraHelper.getStroboscopeStatus().observe(this, (isOn -> {
+            helper.getNormalFlashStatus().observe(this, (isOn -> changeButtonColors(FlashlightMode.NORMAL, isOn)));
+            helper.getSosStatus().observe(this, (isOn -> changeButtonColors(FlashlightMode.SOS, isOn)));
+            helper.getStroboscopeStatus().observe(this, (isOn -> {
                 changeButtonColors(FlashlightMode.STROBOSCOPE, isOn);
                 binding.stroboscopeInterval.setVisibility(isOn ? View.VISIBLE : View.GONE);
                 binding.stroboscopeIntervalSlider.setVisibility(isOn ? View.VISIBLE : View.GONE);
@@ -98,14 +119,14 @@ public class MainActivity extends AppCompatActivity {
             binding.sosButton.setOnClickListener(v -> helper.toggleSos(this));
             binding.stroboscopeButton.setOnClickListener(v -> helper.toggleStroboscope(this));
             float stroboscopeIntervalInPreferences = defaultPreferences.getFloat("stroboscope_interval", -1);
-            CameraHelper.setStroboscopeInterval(stroboscopeIntervalInPreferences != -1 ? (int) (stroboscopeIntervalInPreferences * 1000) : 500);
+            helper.setStroboscopeInterval(stroboscopeIntervalInPreferences != -1 ? (int) (stroboscopeIntervalInPreferences * 1000) : 500);
             binding.stroboscopeIntervalSlider.setValue(stroboscopeIntervalInPreferences != -1 ? stroboscopeIntervalInPreferences : 0.5F);
             binding.stroboscopeIntervalSlider.addOnSliderTouchListener(new Slider.OnSliderTouchListener() {
                 @Override
                 public void onStartTrackingTouch(@NonNull Slider slider) {}
                 @Override
                 public void onStopTrackingTouch(@NonNull Slider slider) {
-                    CameraHelper.setStroboscopeInterval((int) (slider.getValue() * 1000));
+                    helper.setStroboscopeInterval((int) (slider.getValue() * 1000));
                 }
             });
         }
@@ -115,6 +136,12 @@ public class MainActivity extends AppCompatActivity {
     protected void onPause() {
         super.onPause();
         defaultPreferences.edit().putFloat("stroboscope_interval", binding.stroboscopeIntervalSlider.getValue()).apply();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        unregisterReceiver(turnOffFlashlightOnScreenOffReceiver);
     }
 
     @Override
@@ -166,8 +193,8 @@ public class MainActivity extends AppCompatActivity {
             binding.progressCircular.setOnSeekBarChangeListener(new CircularSeekBar.OnCircularSeekBarChangeListener() {
                 @Override
                 public void onProgressChanged(@Nullable CircularSeekBar circularSeekBar, float v, boolean b) {
-                    CameraHelper.setFlashlightStrength(Math.round(v + 1));
-                    if (Boolean.TRUE.equals(CameraHelper.getNormalFlashStatus().getValue()))
+                    helper.setFlashlightStrength(Math.round(v + 1));
+                    if (Boolean.TRUE.equals(helper.getNormalFlashStatus().getValue()))
                         helper.turnOnFlashWithStrength(MainActivity.this);
                 }
                 @Override
@@ -178,7 +205,7 @@ public class MainActivity extends AppCompatActivity {
                 @Override
                 public void onStartTrackingTouch(@Nullable CircularSeekBar circularSeekBar) {}
             });
-            binding.progressCircular.setProgress(CameraHelper.getFlashlightStrength() - 1);
+            binding.progressCircular.setProgress(helper.getFlashlightStrength() - 1);
             binding.powerCenter.setOnClickListener(v -> helper.toggleNormalFlash(this));
         } else if (getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)) {
             binding.progressCircular.setOnSeekBarChangeListener(null);
@@ -231,7 +258,7 @@ public class MainActivity extends AppCompatActivity {
         binding.progressCircular.setPointerColor(Color.parseColor("#FFB137"));
         binding.progressCircular.setEnabled(true);
         if (defaultPreferences.getBoolean("no_flash_when_screen", true) && getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH))
-            turnOff();
+            helper.turnOffAll(this);
         binding.rootLayout.setBackgroundColor(Color.parseColor("#FFFFFF")); //force set white, because it does not make sense for the app to be dark when using screen light
         if (binding.progressCircular.getProgress() > 0) {
             binding.progressCircular.setOnSeekBarChangeListener(null);
@@ -253,18 +280,6 @@ public class MainActivity extends AppCompatActivity {
             public void onStartTrackingTouch(CircularSeekBar seekBar) {}
         });
         binding.powerCenter.setOnClickListener(view -> binding.progressCircular.setProgress(brightness != 100 ? 100 : 0));
-    }
-
-    public void turnOff() {
-        if (Boolean.TRUE.equals(CameraHelper.getNormalFlashStatus().getValue())) {
-            helper.toggleNormalFlash(this);
-        }
-        if (Boolean.TRUE.equals(CameraHelper.getSosStatus().getValue())) {
-            helper.toggleSos(this);
-        }
-        if (Boolean.TRUE.equals(CameraHelper.getStroboscopeStatus().getValue())) {
-            helper.toggleStroboscope(this);
-        }
     }
 
     @Override

--- a/app/src/main/java/rocks/poopjournal/flashy/activities/MainActivity.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/activities/MainActivity.java
@@ -41,7 +41,7 @@ public class MainActivity extends AppCompatActivity {
     private SharedPreferences defaultPreferences;
     private CameraHelper helper;
     private MainActivityBinding binding;
-    private final BroadcastReceiver turnOffFlashlightOnScreenOffReceiver = new ScreenOffBroadcastReceiver();
+    private final ScreenOffBroadcastReceiver turnOffFlashlightOnScreenOffReceiver = new ScreenOffBroadcastReceiver();
     private enum FlashlightMode {
         NORMAL, SOS, STROBOSCOPE
     }
@@ -52,9 +52,9 @@ public class MainActivity extends AppCompatActivity {
                 break;
             case "no_flash_on_device_screen_off":
                 if (sharedPreferences.getBoolean("no_flash_on_device_screen_off", false)) {
-                    registerReceiver(turnOffFlashlightOnScreenOffReceiver, new IntentFilter(Intent.ACTION_SCREEN_OFF));
+                    turnOffFlashlightOnScreenOffReceiver.registerWith(this);
                 } else {
-                    unregisterReceiver(turnOffFlashlightOnScreenOffReceiver);
+                    turnOffFlashlightOnScreenOffReceiver.unregisterWith(this);
                 }
                 break;
             default:
@@ -67,7 +67,7 @@ public class MainActivity extends AppCompatActivity {
         PreferenceManager.setDefaultValues(this, R.xml.root_preferences, false);
         defaultPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         if (defaultPreferences.getBoolean("no_flash_on_device_screen_off", false)) {
-            registerReceiver(turnOffFlashlightOnScreenOffReceiver, new IntentFilter(Intent.ACTION_SCREEN_OFF));
+            turnOffFlashlightOnScreenOffReceiver.registerWith(this);
         }
         defaultPreferences.registerOnSharedPreferenceChangeListener(material3Listener);
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P && defaultPreferences.getString("theme", "system").equals("system"))
@@ -141,7 +141,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        unregisterReceiver(turnOffFlashlightOnScreenOffReceiver);
+        turnOffFlashlightOnScreenOffReceiver.unregisterWith(this);
     }
 
     @Override

--- a/app/src/main/java/rocks/poopjournal/flashy/activities/SettingsActivity.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/activities/SettingsActivity.java
@@ -62,7 +62,7 @@ public class SettingsActivity extends AppCompatActivity {
             SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(requireContext());
             preferences.registerOnSharedPreferenceChangeListener(listener);
             helper = CameraHelper.getInstance(requireContext());
-            if (Boolean.TRUE.equals(CameraHelper.getSosStatus().getValue())) helper.toggleSos(requireContext());
+            if (Boolean.TRUE.equals(helper.getSosStatus().getValue())) helper.toggleSos(requireContext());
 
             ListPreference themePref = findPreference("theme");
             assert themePref != null;
@@ -92,11 +92,14 @@ public class SettingsActivity extends AppCompatActivity {
             assert learnMoreAboutMorseTiming != null;
             SwitchPreferenceCompat noFlashWhenScreen = findPreference("no_flash_when_screen");
             assert noFlashWhenScreen != null;
+            SwitchPreferenceCompat noFlashOnDeviceScreenOff = findPreference("no_flash_on_device_screen_off");
+            assert noFlashOnDeviceScreenOff != null;
             if (!requireContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)) {
                 wordsPerMin.setVisible(false);
                 useFarnsworth.setVisible(false);
                 farnsworthUnitLength.setVisible(false);
                 noFlashWhenScreen.setVisible(false);
+                noFlashOnDeviceScreenOff.setVisible(false);
                 learnMoreAboutMorseTiming.setVisible(false);
             } else {
                 wordsPerMin.setOnBindEditTextListener(editText -> editText.setInputType(InputType.TYPE_CLASS_NUMBER));

--- a/app/src/main/java/rocks/poopjournal/flashy/receivers/ScreenOffBroadcastReceiver.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/receivers/ScreenOffBroadcastReceiver.java
@@ -1,0 +1,40 @@
+package rocks.poopjournal.flashy.receivers;
+
+import static java.util.Objects.requireNonNull;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.view.Display;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.hardware.display.DisplayManagerCompat;
+
+import rocks.poopjournal.flashy.utils.CameraHelper;
+
+public class ScreenOffBroadcastReceiver extends BroadcastReceiver {
+
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT_WATCH)
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        if (action == null) {
+            return;
+        }
+        if (Intent.ACTION_SCREEN_OFF.equals(action) && !isScreenOn(context)) {
+            CameraHelper helper = CameraHelper.getInstance(context);
+            helper.turnOffAll(context);
+        }
+    }
+
+    /**
+     * Checks if the screen is actually turned off because {@link Intent#ACTION_SCREEN_OFF} doesn't necessarily indicate that the screen is off.
+     * @return true if screen is actually turned off
+     */
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT_WATCH)
+    private boolean isScreenOn(Context context) {
+        Display display = requireNonNull(DisplayManagerCompat.getInstance(context).getDisplay(Display.DEFAULT_DISPLAY));
+        return display.getState() != Display.STATE_OFF;
+    }
+}

--- a/app/src/main/java/rocks/poopjournal/flashy/receivers/ScreenOffBroadcastReceiver.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/receivers/ScreenOffBroadcastReceiver.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Build;
 import android.view.Display;
 
@@ -14,6 +15,24 @@ import androidx.core.hardware.display.DisplayManagerCompat;
 import rocks.poopjournal.flashy.utils.CameraHelper;
 
 public class ScreenOffBroadcastReceiver extends BroadcastReceiver {
+
+    private boolean isRegistered = false;
+
+    public void registerWith(Context context) {
+        if (isRegistered) {
+            return;
+        }
+        context.registerReceiver(this, new IntentFilter(Intent.ACTION_SCREEN_OFF));
+        isRegistered = true;
+    }
+
+    public void unregisterWith(Context context) {
+        if (!isRegistered) {
+            return;
+        }
+        context.unregisterReceiver(this);
+        isRegistered = false;
+    }
 
     @RequiresApi(api = Build.VERSION_CODES.KITKAT_WATCH)
     @Override

--- a/app/src/main/java/rocks/poopjournal/flashy/widgets/FlashlightWidgetProvider.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/widgets/FlashlightWidgetProvider.java
@@ -26,7 +26,7 @@ public class FlashlightWidgetProvider extends AppWidgetProvider {
                 PendingIntent pendingIntent = PendingIntent.getActivity(context, 42, intent, PendingIntent.FLAG_IMMUTABLE);
                 remoteViews.setOnClickPendingIntent(R.id.img, pendingIntent);
             } else {
-                if (Boolean.TRUE.equals(CameraHelper.getNormalFlashStatus().getValue())) {
+                if (Boolean.TRUE.equals(CameraHelper.getInstance(context).getNormalFlashStatus().getValue())) {
                     remoteViews.setImageViewResource(R.id.img, R.drawable.flashlight_on);
                 } else
                     remoteViews.setImageViewResource(R.id.img, R.drawable.flashlight_off);

--- a/app/src/main/java/rocks/poopjournal/flashy/widgets/SOSWidgetProvider.java
+++ b/app/src/main/java/rocks/poopjournal/flashy/widgets/SOSWidgetProvider.java
@@ -26,7 +26,7 @@ public class SOSWidgetProvider extends AppWidgetProvider {
                 PendingIntent pendingIntent = PendingIntent.getActivity(context, 42, intent, PendingIntent.FLAG_IMMUTABLE);
                 remoteViews.setOnClickPendingIntent(R.id.img_sos, pendingIntent);
             } else {
-                if (Boolean.TRUE.equals(CameraHelper.getSosStatus().getValue())) {
+                if (Boolean.TRUE.equals(CameraHelper.getInstance(context).getSosStatus().getValue())) {
                     remoteViews.setImageViewResource(R.id.img_sos, R.drawable.sos_on);
                 } else
                     remoteViews.setImageViewResource(R.id.img_sos, R.drawable.sos);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,4 +50,6 @@
     <string name="learn_more_morse_timing">Learn more about Morse code timing</string>
     <string name="md3_subtext">Use Android 12 look and feel</string>
     <string name="md3">Material Design 3</string>
+    <string name="no_flash_on_device_screen_off">Turn off flashlight when turning off device screen</string>
+    <string name="no_flash_on_device_screen_off_subtext">Only works when the app is open</string>
 </resources>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -30,6 +30,13 @@
             app:iconSpaceReserved="false"
             app:defaultValue="true"/>
 
+        <SwitchPreferenceCompat
+            app:key="no_flash_on_device_screen_off"
+            app:title="@string/no_flash_on_device_screen_off"
+            app:summary="@string/no_flash_on_device_screen_off_subtext"
+            app:iconSpaceReserved="false"
+            app:defaultValue="false"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory app:title="@string/sos"


### PR DESCRIPTION
Resolves #101. Note that this feature only works while the app is open due to an Android restriction. (To get it to work while app is closed, I guess I must use a foreground service which is ***very*** inappropriate for a flashlight app).
While I'm at it, I also refactored the camera logic a bit, focusing on improving Android 13+ device handling, which **might** affect #117, although I'm not entirely sure... since I still don't have a Android 13 device.