### PR TITLE
Update build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    namespace 'rocks.poopjournal.flashy'
 }
 
 dependencies {


### PR DESCRIPTION
Saya melihat ada kesalahan sintaks di bagian namespace 'rocks.poopjournal.flashy'. Fungsi namespace tidak ada dalam konfigurasi Gradle. Jika Anda mencoba menetapkan nama paket aplikasi, itu sudah ditetapkan dengan benar di applicationId di dalam defaultConfig.